### PR TITLE
Remove mention of OpenSSH from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 U2F Zero
 ========
 
-U2F Zero is an open source U2F token for 2 factor authentication.  It is implemented securely.  It works with Google accounts, Github, Duo, OpenSSH, and anything else supporting U2F.
+U2F Zero is an open source U2F token for 2 factor authentication.  It is implemented securely.  It works with Google accounts, Github, Duo, and anything else supporting U2F.
 
 ![](http://i.imgur.com/dQpo9wC.jpg "The door keys are not used")
 


### PR DESCRIPTION
OpenSSH does not support U2F as an authentication mechanism. There was
a patch proposed, but it has not been merged and future support
remains unclear:

https://bugzilla.mindrot.org/show_bug.cgi?id=2319