### PR TITLE
Rewind key slot to 0, when num_issued exceeds 15. 

### DIFF
--- a/firmware/src/u2f_atecc.c
+++ b/firmware/src/u2f_atecc.c
@@ -323,6 +323,9 @@ int8_t u2f_new_keypair(uint8_t * handle, uint8_t * appid, uint8_t * pubkey)
 	if (keyslot > U2F_NUM_KEYS-1)
 	{
 		app_wink(U2F_DEFAULT_COLOR_WINK_OUT_OF_SPACE);
+		// rewind to keyslot 0
+		keyslot = 0;
+		key_store.num_issued = 0;
 		return -1;
 	}
 	watchdog();


### PR DESCRIPTION
Rewind key slot to 0, when num_issued exceeds 15. So that the oldest key can be wiped with the other 14 keys remained.

Note: When the '16th' key is being issued, it will blink first and fail, and then the counter will rewind to 0. The next enroll will be successful, and saved at slot 0.