### PR TITLE
Add missing ecdsa to python client requirements

### DIFF
--- a/tools/u2f_zero_client/requirements.txt
+++ b/tools/u2f_zero_client/requirements.txt
@@ -1,2 +1,3 @@
 setuptools
 hidapi
+ecdsa


### PR DESCRIPTION
As mentioned in https://github.com/conorpp/u2f-zero/blob/master/tools/u2f_zero_client/client.py#L49 ``python ecdsa module is required`` so I append them to requirements.